### PR TITLE
docs: update repository URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ This repository contains explorations and automations using [n8n](https://n8n.io
 1. Clone this repository and install dependencies:
 
    ```bash
-   git clone https://github.com/yourusername/explore-n8n.git
+   git clone https://github.com/TheRobBrennan/explore-n8n.git
    cd explore-n8n
    npm install
    ```


### PR DESCRIPTION
# Description

Updated the clone URL in the README to use the correct repository URL (TheRobBrennan/explore-n8n) instead of the placeholder.

## Type of Change

```
version: docs
```

## Testing

- [x] I have tested these changes locally using `act`
- [x] All existing tests pass
- [x] My commits are signed with GPG
