### PR TITLE
chore: update n8n container timezone to America/Los_Angeles

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,7 @@ services:
     ports:
       - "5678:5678"
     environment:
+      - TZ=America/Los_Angeles
       - N8N_HOST=localhost
       - N8N_PORT=5678
       - N8N_PROTOCOL=http


### PR DESCRIPTION
## Description

This PR updates the n8n Docker container's timezone to `America/Los_Angeles` to ensure all scheduled workflows and timestamps reflect the correct local time for Seattle.

### Changes Made
- Added `TZ=America/Los_Angeles` environment variable to the n8n service in `docker-compose.yml`
- This change ensures that all scheduled workflows and timestamp operations use the correct timezone

## Type of Change

version: chore    # General maintenance

## Testing

- [x] I have tested these changes locally using `act`
- [x] All existing tests pass
- [x] My commits are signed with GPG

## Impact
- All scheduled workflows will now use Pacific Time (PT) for their execution times
- Timestamps in logs and workflow executions will reflect the correct local time
- No breaking changes to existing functionality, only timezone alignment

## Notes
- The timezone change requires a container restart to take effect
- The change is persistent across container restarts as it's defined in the docker-compose configuration
